### PR TITLE
docs: add lifecycle section to setup

### DIFF
--- a/blog/2023-06-29-v0.1.0-gamma.0.md
+++ b/blog/2023-06-29-v0.1.0-gamma.0.md
@@ -92,7 +92,7 @@ You can then import from `@capi/rococo` and `@capi/rococo-contracts`, which will
 automatically spawn the network.
 
 For more information, refer to our guide on
-[development setup](/setup/development).
+[development setup](/setup/development_nets).
 
 ### Automatic Binary Installation
 

--- a/docs/basics/extrinsics.md
+++ b/docs/basics/extrinsics.md
@@ -4,7 +4,7 @@ At the heart of any extrinsic is some call data. Let's first create some call
 data to represent one of the most common runtime operations: a balance transfer.
 
 > Note: these examples assume there are two
-> [test users](/setup/development#development-users) in scope (`alexa` and
+> [test users](/setup/development_nets#development-users) in scope (`alexa` and
 > `billy`).
 
 ```ts

--- a/docs/setup/development_nets.md
+++ b/docs/setup/development_nets.md
@@ -1,4 +1,4 @@
-# Development
+# Development Networks
 
 During development, you'll likely want to run the Capi server as to make use of
 ephemeral development networks.

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -1,5 +1,19 @@
 # Setup
 
+## Lifecycle
+
+Let's briefly touch on the Capi usage lifecycle at a high level.
+
+1. In Node workspaces, we install Capi (not applicable to Deno workspaces).
+2. We define our "net specs", a file which exports descriptions of what chains
+   we're targeting.
+3. Whenever we update our net specs, we "sync." This updates your manifest
+   (usually a `package.json` or `import_map.json`) with the Capi-generated
+   dependencies.
+
+During development, we may also use Capi to launch and test against ephemeral
+networks, but more on this [later](./development_nets).
+
 ## Installation
 
 NPM-install `capi` (not applicable for Deno users).
@@ -52,7 +66,7 @@ import { net } from "capi/nets"
 export const polkadot = net.ws({ url: "wss://rpc.polkadot.io" })
 ```
 
-This file is covered more in depth in [the `nets.ts` section](./nets).
+This file is covered more in depth in [the `nets.ts` section](./net_specs).
 
 > Note: you can forgo this setup if your app determines target chain at runtime.
 > For an example of such usage, see

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -4,9 +4,9 @@
 
 Let's briefly touch on the Capi usage lifecycle at a high level.
 
-1. In Node workspaces, we install Capi (not applicable to Deno workspaces).
-2. We define our "net specs", a file which exports descriptions of what chains
-   we're targeting.
+1. In Node projects, we install Capi (not applicable to Deno projects).
+2. We define our "net specs", a file which exports descriptions (i.e. net specs)
+   of what chains we're targeting.
 3. Whenever we update our net specs, we "sync." This updates your manifest
    (usually a `package.json` or `import_map.json`) with the Capi-generated
    dependencies.

--- a/docs/setup/net_specs.md
+++ b/docs/setup/net_specs.md
@@ -1,7 +1,7 @@
 # Net Specs
 
-Your net spec file (usually `nets.ts`) describes all the networks with which you
-wish to interact.
+Your net spec file, `nets.ts`, describes all the networks with which you wish to
+interact.
 
 Import `net`.
 

--- a/docs/setup/net_specs.md
+++ b/docs/setup/net_specs.md
@@ -1,6 +1,6 @@
-# Nets
+# Net Specs
 
-Create a `nets.ts` file. This file will describe all the networks with which you
+Your net spec file (usually `nets.ts`) describes all the networks with which you
 wish to interact.
 
 Import `net`.
@@ -155,5 +155,5 @@ export const polkadot = net.ws({
 })
 ```
 
-We'll dig into this in [the next section](/setup/development), where we'll cover
-making use of the Capi development server.
+We'll dig into this in [the next section](/setup/development_nets), where we'll
+cover making use of the Capi development server.

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,9 +10,9 @@ const sidebars = {
         id: "setup/index",
       },
       items: [
-        "setup/development",
+        "setup/development_nets",
         "setup/build_tool_integration",
-        "setup/nets",
+        "setup/net_specs",
       ],
     },
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -10,9 +10,9 @@ const sidebars = {
         id: "setup/index",
       },
       items: [
+        "setup/net_specs",
         "setup/development_nets",
         "setup/build_tool_integration",
-        "setup/net_specs",
       ],
     },
     {


### PR DESCRIPTION
Addresses some feedback from @vjjft that setup should be preceded by an overview of the lifecycle of Capi development.