### PR TITLE
docs: subshape rename

### DIFF
--- a/docs/basics/rune.md
+++ b/docs/basics/rune.md
@@ -71,7 +71,7 @@ The signature of the `accountInfo` Rune is as follows.
 ```ts
 ValueRune<
   AccountInfo | undefined, // the `T` type parameter, the main type
-  ConnectionError | ServerError | $.ScaleError // the `U` type parameter, what has been unhandled
+  ConnectionError | ServerError | $.ShapeError // the `U` type parameter, what has been unhandled
 >
 ```
 
@@ -93,6 +93,6 @@ In this example, the `accountInfo` Rune now has the following type.
 ```ts
 ValueRune<
   AccountInfo | undefined | "the fallback",
-  ConnectionError | $.ScaleError
+  ConnectionError | $.ShapeError
 >
 ```

--- a/docs/basics/storage.md
+++ b/docs/basics/storage.md
@@ -28,7 +28,7 @@ const accountInfo = polkadot.System.Account.value(publicKey)
 
 accountInfo satisfies ValueRune<
   AccountInfo | undefined,
-  ConnectionError | ServerError | $.ScaleError
+  ConnectionError | ServerError | $.ShapeError
 >
 ```
 
@@ -57,7 +57,7 @@ const accountEntries = await polkadot.System.Account.entries({
 
 accountEntries satisfies Rune<
   [Uint8Array, AccountInfo][],
-  ConnectionError | ServerError | $.ScaleError
+  ConnectionError | ServerError | $.ShapeError
 >
 ```
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -7,7 +7,7 @@ types may remain consistent across chains, many may differ. On one chain,
 (hypothetical) chain, perhaps `AccountData` describes non-fungible assets,
 reputation, linked accounts or something else entirely. Capi's codegen outputs
 TypeScript-idiomatic equivalents of the Rust-declared types, along with
-utilities such as object and variant factories, type guards and runtime
+utilities such as object and variant factories, type guards and
 [shapes](https://github.com/paritytech/subshape). This reduces the friction of
 targeting a Rust-defined environment from your JavaScript environment. It also
 ensures optimal type safety!

--- a/docs/types.md
+++ b/docs/types.md
@@ -8,9 +8,9 @@ types may remain consistent across chains, many may differ. On one chain,
 reputation, linked accounts or something else entirely. Capi's codegen outputs
 TypeScript-idiomatic equivalents of the Rust-declared types, along with
 utilities such as object and variant factories, type guards and runtime
-[scale-ts](https://github.com/paritytech/scale-ts) codecs. This reduces the
-friction of targeting a Rust-defined environment from your JavaScript
-environment. It also ensures optimal type safety!
+[shapes](https://github.com/paritytech/subshape). This reduces the friction of
+targeting a Rust-defined environment from your JavaScript environment. It also
+ensures optimal type safety!
 
 ## Conversion Table
 
@@ -172,8 +172,9 @@ if (RuntimeEvent.isContracts(event)) {
 
 ## Codecs
 
-The `$`-prefixed, camel-cased type name is actually a `scale-ts` codec. This
-codec can be used for many use cases.
+The `$`-prefixed, camel-cased type name is actually a
+[`subShape`](https://github.com/paritytech/subshape) "shape". This codec can be
+used for many use cases.
 
 For instance, we may want to perform runtime validation of some untrusted data.
 
@@ -207,5 +208,5 @@ const appRouter = t.router({
 })
 ```
 
-> Note: scale-ts codecs are supported natively by tRPC for typing and
-> validation.
+> Note: [shapes](https://github.com/paritytech/subshape) are supported natively
+> by tRPC for typing and validation.


### PR DESCRIPTION
Update docs to reflect `scale-ts` rename -> `subshape`