### PR TITLE
docs: add web crypto api node shim documentation

### DIFF
--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -18,9 +18,20 @@ networks, but more on this [later](./development_nets).
 
 NPM-install `capi` (not applicable for Deno users).
 
-> Note: The minimum supported Node version is 20, as we require the
-> [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
-> be accessible from `globalThis.crypto` for the sake of browser compatibility.
+> Note: The minimum supported Node version is 20.3.1, as Capi requires the
+> standard [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
+
+<details>
+<summary>Shimming Web Crypto API</summary>
+<br />
+
+For previous major versions of Node, you can shim `globalThis.crypto`:
+
+```ts
+globalThis.crypto = require("node:crypto").webcrypto
+```
+
+</details>
 
 ```sh
 npm i capi

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -16,16 +16,16 @@ networks, but more on this [later](./development_nets).
 
 ## Requirements
 
-The minimum supported Node version is 20.3.1, as Capi requires the standard
-[Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
-To use Capi in previous major versions of Node, you can shim `globalThis.crypto`
-as follows.
+### Web Crypto API
+
+Capi requires the standard
+[Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api)
+(Node v20.3.1 and above). To use Capi in previous major versions of Node, you
+can shim `globalThis.crypto` as follows.
 
 ```ts
 globalThis.crypto = require("node:crypto").webcrypto
 ```
-
-> Deno-based Capi projects require the latest v1.x Deno release.
 
 ## Installation
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -18,12 +18,16 @@ networks, but more on this [later](./development_nets).
 
 NPM-install `capi` (not applicable for Deno users).
 
-> Note: The minimum supported Node version is 20.3.1, as Capi requires the
-> standard [Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
+```sh
+npm i capi
+```
 
 <details>
-<summary>Shimming Web Crypto API</summary>
+<summary>Node Version Support </summary>
 <br />
+
+The minimum supported Node version is 20.3.1, as Capi requires the standard
+[Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
 
 For previous major versions of Node, you can shim `globalThis.crypto`:
 
@@ -32,10 +36,6 @@ globalThis.crypto = require("node:crypto").webcrypto
 ```
 
 </details>
-
-```sh
-npm i capi
-```
 
 ## CLI
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -14,6 +14,19 @@ Let's briefly touch on the Capi usage lifecycle at a high level.
 During development, we may also use Capi to launch and test against ephemeral
 networks, but more on this [later](./development_nets).
 
+## Requirements
+
+The minimum supported Node version is 20.3.1, as Capi requires the standard
+[Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
+To use Capi in previous major versions of Node, you can shim `globalThis.crypto`
+as follows.
+
+```ts
+globalThis.crypto = require("node:crypto").webcrypto
+```
+
+> Deno-based Capi projects require the latest v1.x Deno release.
+
 ## Installation
 
 NPM-install `capi` (not applicable for Deno users).
@@ -22,24 +35,9 @@ NPM-install `capi` (not applicable for Deno users).
 npm i capi
 ```
 
-<details>
-<summary>Node Version Support </summary>
-<br />
-
-The minimum supported Node version is 20.3.1, as Capi requires the standard
-[Web Crypto API](https://nodejs.org/docs/latest-v20.x/api/webcrypto.html#web-crypto-api).
-
-For previous major versions of Node, you can shim `globalThis.crypto`:
-
-```ts
-globalThis.crypto = require("node:crypto").webcrypto
-```
-
-</details>
-
 ## CLI
 
-You may also want to add Capi to your scripts/tasks for convenience.
+You may want to add Capi to your scripts/tasks for convenience.
 
 `package.json`
 


### PR DESCRIPTION
[capi#1164](https://github.com/paritytech/capi/pull/1164)

Adds documentation for how to shim the web crypto api in previous versions of node. also updates the node version requirement.

**Screenshots:** 

![image](https://github.com/paritytech/docs.capi.dev/assets/21375952/2eaf32b2-de3d-4b60-ad2b-f7440b0f1c40)

![image](https://github.com/paritytech/docs.capi.dev/assets/21375952/992f47b4-35bb-4391-b894-6cb7a2c5a2eb)
